### PR TITLE
fix: further use esc_attr on sanitized args to prevent XSS

### DIFF
--- a/embedded-cdn/README.txt
+++ b/embedded-cdn/README.txt
@@ -4,7 +4,7 @@ Donate link: https://www.canadahelps.org/en/why-canadahelps/support-us/
 Tags: iframe, embed
 Requires at least: 3.0
 Tested up to: 6.7
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/embedded-cdn/embedded-cdn.php
+++ b/embedded-cdn/embedded-cdn.php
@@ -38,8 +38,8 @@ function embeded_cdn_plugin_add_shortcode_cb($atts) {
 	$html .= ' id="ch_cdn_embed"';
 	$html .= ' type="text/javascript"';
 	$html .= ' data-cfasync="false"';
-	$html .= ' data-page-id="' . $atts["id"] . '"';
-	$html .= ' data-language="' . $atts["language"] . '"';
+	$html .= ' data-page-id="' . esc_attr($atts["id"]) . '"';
+	$html .= ' data-language="' . esc_attr($atts["language"]) . '"';
 	$html .= ' src="https://www.canadahelps.org/services/wa/js/apps/donatenow/embed.min.js"';
 	$html .= '></script>';
 	$html .= "\n";

--- a/embedded-cdn/embedded-cdn.php
+++ b/embedded-cdn/embedded-cdn.php
@@ -3,7 +3,7 @@
 Plugin Name: CanadaHelps Embedded Donation Form
 Plugin URI:  https://github.com/CanadaHelps/embedded-cdn
 Description: Adds a shortcode to support embedded custom donate now pages. [embedcdn id="168"]
-Version:     1.0.1
+Version:     1.0.2
 Author:      CanadaHelps.org
 Author URI:  https://www.canadahelps.org/
 License:     GPLv3


### PR DESCRIPTION
Wordpress feedback: Further use esc_attr to escape input args